### PR TITLE
Add support for arm64 docker builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,3 +28,4 @@ jobs:
         with:
           push: true
           tags: cloudlena/s3manager:latest
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
The build takes a few minutes longer, but in the end it seems to work:

<img width="482" alt="image" src="https://user-images.githubusercontent.com/3781551/164105035-04846a9c-3486-49a2-bc06-4b44f47f7961.png">
