### PR TITLE
Add S3 Server Side Encryption support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The application can be configured with the following environment variables:
 - `LIST_RECURSIVE`: List all objects in buckets recursively (defaults to `false`)
 - `USE_IAM`: Use IAM role instead of key pair (defaults to `false`)
 - `IAM_ENDPOINT`: Endpoint for IAM role retrieving (Can be blank for AWS)
+- `SSE_TYPE`: Specified server side encrpytion (defaults blank) Valid values can be `SSE`, `KMS`, `SSE-C` all others values don't enable the SSE
+- `SSE_KEY`: The key needed for SSE method (only for `KMS` and `SSE-C`)
 
 ### Build and Run Locally
 

--- a/internal/app/s3manager/create_object.go
+++ b/internal/app/s3manager/create_object.go
@@ -8,10 +8,11 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/encrypt"
 )
 
 // HandleCreateObject uploads a new object.
-func HandleCreateObject(s3 S3) http.HandlerFunc {
+func HandleCreateObject(s3 S3, sseInfo SSEType) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		bucketName := mux.Vars(r)["bucketName"]
 
@@ -32,6 +33,23 @@ func HandleCreateObject(s3 S3) http.HandlerFunc {
 		}(file)
 
 		opts := minio.PutObjectOptions{ContentType: "application/octet-stream"}
+
+		if sseInfo.Type == "KMS" {
+			opts.ServerSideEncryption, _ = encrypt.NewSSEKMS(sseInfo.Key, nil)
+		}
+
+		if sseInfo.Type == "SSE" {
+			opts.ServerSideEncryption = encrypt.NewSSE()
+		}
+
+		if sseInfo.Type == "SSE-C" {
+			opts.ServerSideEncryption, err = encrypt.NewSSEC([]byte(sseInfo.Key))
+			if err != nil {
+				handleHTTPError(w, fmt.Errorf("error setting SSE-C key: %w", err))
+				return
+			}
+		}
+
 		_, err = s3.PutObject(r.Context(), bucketName, header.Filename, file, -1, opts)
 		if err != nil {
 			handleHTTPError(w, fmt.Errorf("error putting object: %w", err))

--- a/internal/app/s3manager/s3.go
+++ b/internal/app/s3manager/s3.go
@@ -19,3 +19,8 @@ type S3 interface {
 	RemoveBucket(ctx context.Context, bucketName string) error
 	RemoveObject(ctx context.Context, bucketName, objectName string, opts minio.RemoveObjectOptions) error
 }
+
+type SSEType struct {
+	Type string
+	Key string
+}

--- a/main.go
+++ b/main.go
@@ -69,6 +69,11 @@ func main() {
 	viper.SetDefault("PORT", "8080")
 	port := viper.GetString("PORT")
 
+	viper.SetDefault("SSE_TYPE", "")
+	viper.SetDefault("SSE_KEY", "")
+
+	sseType := s3manager.SSEType{Type: viper.GetString("SSE_TYPE"), Key: viper.GetString("SSE_KEY")}
+
 	// Set up templates
 	templates, err := fs.Sub(templateFS, "web/template")
 	if err != nil {
@@ -111,7 +116,7 @@ func main() {
 	if allowDelete {
 		r.Handle("/api/buckets/{bucketName}", s3manager.HandleDeleteBucket(s3)).Methods(http.MethodDelete)
 	}
-	r.Handle("/api/buckets/{bucketName}/objects", s3manager.HandleCreateObject(s3)).Methods(http.MethodPost)
+	r.Handle("/api/buckets/{bucketName}/objects", s3manager.HandleCreateObject(s3, sseType)).Methods(http.MethodPost)
 	r.Handle("/api/buckets/{bucketName}/objects/{objectName:.*}", s3manager.HandleGetObject(s3, forceDownload)).Methods(http.MethodGet)
 	if allowDelete {
 		r.Handle("/api/buckets/{bucketName}/objects/{objectName:.*}", s3manager.HandleDeleteObject(s3)).Methods(http.MethodDelete)


### PR DESCRIPTION
Hello,

Just a pull request to allow set and enable server side encryption when uploading objects to the S3 buckets.

More information about the SSE [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/serv-side-encryption.html) on AWS documentation

PS: It's my first contribution in go. I take all suggestion to improve this features :)