### PR TITLE
Allow authorization signature to be skipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The application can be configured with the following environment variables:
 - `SECRET_ACCESS_KEY`: Your S3 secret access key (required) (works only if `USE_IAM` is `false`)
 - `USE_SSL`: Whether your S3 server uses SSL or not (defaults to `true`)
 - `SKIP_SSL_VERIFICATION`: Whether the HTTP client should skip SSL verification (defaults to `false`)
-- `SKIP_SIGNATURE_AUTHORIZATION`: Whether signature authorization should be skipped (defaults to `false`)
+- `SKIP_SIGNATURE`: Whether signature should be skipped (defaults to `false`)
 - `PORT`: The port the s3manager app should listen on (defaults to `8080`)
 - `ALLOW_DELETE`: Enable buttons to delete objects (defaults to `true`)
 - `FORCE_DOWNLOAD`: Add response headers for object downloading instead of opening in a new tab (defaults to `true`)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The application can be configured with the following environment variables:
 - `SECRET_ACCESS_KEY`: Your S3 secret access key (required) (works only if `USE_IAM` is `false`)
 - `USE_SSL`: Whether your S3 server uses SSL or not (defaults to `true`)
 - `SKIP_SSL_VERIFICATION`: Whether the HTTP client should skip SSL verification (defaults to `false`)
-- `SKIP_SIGNATURE_AUTHORIZATION`: Whether the signature authorization should be skipped (defaults to `false`)
+- `SKIP_SIGNATURE_AUTHORIZATION`: Whether signature authorization against S3 server should be skipped (defaults to `false`)
 - `PORT`: The port the s3manager app should listen on (defaults to `8080`)
 - `ALLOW_DELETE`: Enable buttons to delete objects (defaults to `true`)
 - `FORCE_DOWNLOAD`: Add response headers for object downloading instead of opening in a new tab (defaults to `true`)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The application can be configured with the following environment variables:
 - `SECRET_ACCESS_KEY`: Your S3 secret access key (required) (works only if `USE_IAM` is `false`)
 - `USE_SSL`: Whether your S3 server uses SSL or not (defaults to `true`)
 - `SKIP_SSL_VERIFICATION`: Whether the HTTP client should skip SSL verification (defaults to `false`)
+- `SKIP_SIGNATURE_AUTHORIZATION`: Whether the signature authorization should be skipped (defaults to `false`)
 - `PORT`: The port the s3manager app should listen on (defaults to `8080`)
 - `ALLOW_DELETE`: Enable buttons to delete objects (defaults to `true`)
 - `FORCE_DOWNLOAD`: Add response headers for object downloading instead of opening in a new tab (defaults to `true`)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The application can be configured with the following environment variables:
 - `SECRET_ACCESS_KEY`: Your S3 secret access key (required) (works only if `USE_IAM` is `false`)
 - `USE_SSL`: Whether your S3 server uses SSL or not (defaults to `true`)
 - `SKIP_SSL_VERIFICATION`: Whether the HTTP client should skip SSL verification (defaults to `false`)
-- `SKIP_SIGNATURE_AUTHORIZATION`: Whether signature authorization against S3 server should be skipped (defaults to `false`)
+- `SKIP_SIGNATURE_AUTHORIZATION`: Whether signature authorization should be skipped (defaults to `false`)
 - `PORT`: The port the s3manager app should listen on (defaults to `8080`)
 - `ALLOW_DELETE`: Enable buttons to delete objects (defaults to `true`)
 - `FORCE_DOWNLOAD`: Add response headers for object downloading instead of opening in a new tab (defaults to `true`)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The application can be configured with the following environment variables:
 - `SECRET_ACCESS_KEY`: Your S3 secret access key (required) (works only if `USE_IAM` is `false`)
 - `USE_SSL`: Whether your S3 server uses SSL or not (defaults to `true`)
 - `SKIP_SSL_VERIFICATION`: Whether the HTTP client should skip SSL verification (defaults to `false`)
-- `SKIP_SIGNATURE`: Whether signature should be skipped (defaults to `false`)
+- `SKIP_SIGNATURE`: Whether authorization signature should be skipped or not (defaults to `false`)
 - `PORT`: The port the s3manager app should listen on (defaults to `8080`)
 - `ALLOW_DELETE`: Enable buttons to delete objects (defaults to `true`)
 - `FORCE_DOWNLOAD`: Add response headers for object downloading instead of opening in a new tab (defaults to `true`)

--- a/main.go
+++ b/main.go
@@ -143,7 +143,7 @@ func main() {
 		opts.Creds = credentials.NewIAM(configuration.IamEndpoint)
 	} else {
 		if (configuration.SkipSignature) {
-			opts.Creds = credentials.NewStatic(configuration.AccessKeyID, configuration.SecretAccessKey, "", SignatureType.SignatureAnonymous)
+			opts.Creds = credentials.NewStatic(configuration.AccessKeyID, configuration.SecretAccessKey, "", credentials.SignatureAnonymous)
 		} else {
 			opts.Creds = credentials.NewStaticV4(configuration.AccessKeyID, configuration.SecretAccessKey, "")
 		}

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ type configuration struct {
 	ForceDownload       bool
 	UseSSL              bool
 	SkipSSLVerification bool
+	SkipSignature       bool
 	ListRecursive       bool
 	Port                string
 	Timeout             int32
@@ -80,6 +81,9 @@ func parseConfiguration() configuration {
 	viper.SetDefault("SKIP_SSL_VERIFICATION", false)
 	skipSSLVerification := viper.GetBool("SKIP_SSL_VERIFICATION")
 
+	viper.SetDefault("SKIP_SIGNATURE", false)
+	skipSignature := viper.GetBool("SKIP_SIGNATURE")
+
 	listRecursive := viper.GetBool("LIST_RECURSIVE")
 
 	viper.SetDefault("PORT", "8080")
@@ -90,6 +94,7 @@ func parseConfiguration() configuration {
 
 	viper.SetDefault("SSE_TYPE", "")
 	sseType := viper.GetString("SSE_TYPE")
+	
 	viper.SetDefault("SSE_KEY", "")
 	sseKey := viper.GetString("SSE_KEY")
 
@@ -104,6 +109,7 @@ func parseConfiguration() configuration {
 		ForceDownload:       forceDownload,
 		UseSSL:              useSSL,
 		SkipSSLVerification: skipSSLVerification,
+		SkipSignature:       skipSignature,
 		ListRecursive:       listRecursive,
 		Port:                port,
 		Timeout:             timeout,
@@ -136,7 +142,11 @@ func main() {
 	if configuration.UseIam {
 		opts.Creds = credentials.NewIAM(configuration.IamEndpoint)
 	} else {
-		opts.Creds = credentials.NewStaticV4(configuration.AccessKeyID, configuration.SecretAccessKey, "")
+		if (configuration.SkipSignature) {
+			opts.Creds = credentials.NewStatic(configuration.AccessKeyID, configuration.SecretAccessKey, "", SignatureType.SignatureAnonymous)
+		} else {
+			opts.Creds = credentials.NewStaticV4(configuration.AccessKeyID, configuration.SecretAccessKey, "")
+		}
 	}
 
 	if configuration.Region != "" {


### PR DESCRIPTION
Some non-AWS S3 servers don't support signature authorization.
This update would allow users to deactivate it.
SKIP_SIGNATURE defaults to false so default behavior is used if it's not set

PS: I'm not a go developer so i'm ready to make any changes that you request