### PR TITLE
Support for multiple S3 backends

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,21 @@ services:
     ports:
       - 8080:8080
     environment:
-      - ENDPOINT=s3:9000
-      - ACCESS_KEY_ID=s3manager
-      - SECRET_ACCESS_KEY=s3manager
-      - USE_SSL=false
+      # S3 Instance 1: my-first-instance
+      - 1_NAME=my-first-instance
+      - 1_ENDPOINT=s3:9000
+      - 1_ACCESS_KEY_ID=s3manager
+      - 1_SECRET_ACCESS_KEY=s3manager
+      - 1_USE_SSL=false
+      # S3 Instance 2: my-second-instance
+      - 2_NAME=my-second-instance
+      - 2_ENDPOINT=s3-2:9000
+      - 2_ACCESS_KEY_ID=s3manager2
+      - 2_SECRET_ACCESS_KEY=s3manager2
+      - 2_USE_SSL=false
     depends_on:
       - s3
+      - s3-2
   s3:
     container_name: s3
     image: docker.io/minio/minio
@@ -21,5 +30,17 @@ services:
     environment:
       - MINIO_ACCESS_KEY=s3manager
       - MINIO_SECRET_KEY=s3manager
+      - MINIO_ADDRESS=0.0.0.0:9000
+      - MINIO_CONSOLE_ADDRESS=0.0.0.0:9001
+  s3-2:
+    container_name: s3-2
+    image: docker.io/minio/minio
+    command: server /data
+    ports:
+      - 9002:9000
+      - 9003:9001
+    environment:
+      - MINIO_ACCESS_KEY=s3manager2
+      - MINIO_SECRET_KEY=s3manager2
       - MINIO_ADDRESS=0.0.0.0:9000
       - MINIO_CONSOLE_ADDRESS=0.0.0.0:9001

--- a/internal/app/s3manager/instance_handlers.go
+++ b/internal/app/s3manager/instance_handlers.go
@@ -1,0 +1,68 @@
+package s3manager
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// S3InstanceInfo represents the information about an S3 instance for API responses
+type S3InstanceInfo struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// HandleGetS3Instances returns all available S3 instances
+func HandleGetS3Instances(manager *MultiS3Manager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		instances := manager.GetAllInstances()
+		current := manager.GetCurrentInstance()
+		
+		response := struct {
+			Instances []S3InstanceInfo `json:"instances"`
+			Current   string           `json:"current"`
+		}{
+			Instances: make([]S3InstanceInfo, len(instances)),
+			Current:   current.ID,
+		}
+		
+		for i, instance := range instances {
+			response.Instances[i] = S3InstanceInfo{
+				ID:   instance.ID,
+				Name: instance.Name,
+			}
+		}
+		
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}
+}
+
+// HandleSwitchS3Instance switches to a specific S3 instance
+func HandleSwitchS3Instance(manager *MultiS3Manager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		instanceID := vars["instanceId"]
+		
+		if instanceID == "" {
+			http.Error(w, "instance ID is required", http.StatusBadRequest)
+			return
+		}
+		
+		err := manager.SetCurrentInstance(instanceID)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		
+		current := manager.GetCurrentInstance()
+		response := S3InstanceInfo{
+			ID:   current.ID,
+			Name: current.Name,
+		}
+		
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}
+}

--- a/internal/app/s3manager/manager_handlers.go
+++ b/internal/app/s3manager/manager_handlers.go
@@ -1,0 +1,230 @@
+package s3manager
+
+import (
+	"fmt"
+	"html/template"
+	"io/fs"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/minio/minio-go/v7"
+)
+
+// HandleBucketsViewWithManager renders all buckets on an HTML page using MultiS3Manager.
+func HandleBucketsViewWithManager(manager *MultiS3Manager, templates fs.FS, allowDelete bool, rootURL string) http.HandlerFunc {
+	type pageData struct {
+		RootURL       string
+		Buckets       []interface{}
+		AllowDelete   bool
+		CurrentS3     *S3Instance
+		S3Instances   []*S3Instance
+		HasError      bool
+		ErrorMessage  string
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		s3 := manager.GetCurrentClient()
+		current := manager.GetCurrentInstance()
+		instances := manager.GetAllInstances()
+
+		buckets, err := s3.ListBuckets(r.Context())
+		
+		data := pageData{
+			RootURL:     rootURL,
+			AllowDelete: allowDelete,
+			CurrentS3:   current,
+			S3Instances: instances,
+			HasError:    false,
+		}
+
+		if err != nil {
+			// Instead of returning an HTTP error, show a user-friendly message
+			data.HasError = true
+			data.ErrorMessage = fmt.Sprintf("Unable to connect to S3 instance '%s'. Please check the credentials and try switching to another instance.", current.Name)
+			data.Buckets = make([]interface{}, 0) // Empty buckets list
+		} else {
+			data.Buckets = make([]interface{}, len(buckets))
+			for i, bucket := range buckets {
+				data.Buckets[i] = bucket
+			}
+		}
+
+		t, err := template.ParseFS(templates, "layout.html.tmpl", "buckets.html.tmpl")
+		if err != nil {
+			handleHTTPError(w, err)
+			return
+		}
+		err = t.ExecuteTemplate(w, "layout", data)
+		if err != nil {
+			handleHTTPError(w, err)
+			return
+		}
+	}
+}
+
+// HandleBucketViewWithManager shows the details page of a bucket using MultiS3Manager.
+func HandleBucketViewWithManager(manager *MultiS3Manager, templates fs.FS, allowDelete bool, listRecursive bool, rootURL string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		s3 := manager.GetCurrentClient()
+		current := manager.GetCurrentInstance()
+		instances := manager.GetAllInstances()
+		
+		// Create a modified handler that includes S3 instance data
+		handler := createBucketViewWithS3Data(s3, templates, allowDelete, listRecursive, rootURL, current, instances)
+		handler(w, r)
+	}
+}
+
+// HandleCreateBucketWithManager creates a new bucket using MultiS3Manager.
+func HandleCreateBucketWithManager(manager *MultiS3Manager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		s3 := manager.GetCurrentClient()
+		// Delegate to the original handler with the current S3 client
+		handler := HandleCreateBucket(s3)
+		handler(w, r)
+	}
+}
+
+// HandleDeleteBucketWithManager deletes a bucket using MultiS3Manager.
+func HandleDeleteBucketWithManager(manager *MultiS3Manager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		s3 := manager.GetCurrentClient()
+		// Delegate to the original handler with the current S3 client
+		handler := HandleDeleteBucket(s3)
+		handler(w, r)
+	}
+}
+
+// HandleCreateObjectWithManager uploads a new object using MultiS3Manager.
+func HandleCreateObjectWithManager(manager *MultiS3Manager, sseInfo SSEType) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		s3 := manager.GetCurrentClient()
+		// Delegate to the original handler with the current S3 client
+		handler := HandleCreateObject(s3, sseInfo)
+		handler(w, r)
+	}
+}
+
+// HandleGenerateURLWithManager generates a presigned URL using MultiS3Manager.
+func HandleGenerateURLWithManager(manager *MultiS3Manager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		s3 := manager.GetCurrentClient()
+		// Delegate to the original handler with the current S3 client
+		handler := HandleGenerateURL(s3)
+		handler(w, r)
+	}
+}
+
+// HandleGetObjectWithManager downloads an object to the client using MultiS3Manager.
+func HandleGetObjectWithManager(manager *MultiS3Manager, forceDownload bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		s3 := manager.GetCurrentClient()
+		// Delegate to the original handler with the current S3 client
+		handler := HandleGetObject(s3, forceDownload)
+		handler(w, r)
+	}
+}
+
+// HandleDeleteObjectWithManager deletes an object using MultiS3Manager.
+func HandleDeleteObjectWithManager(manager *MultiS3Manager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		s3 := manager.GetCurrentClient()
+		// Delegate to the original handler with the current S3 client
+		handler := HandleDeleteObject(s3)
+		handler(w, r)
+	}
+}
+
+// createBucketViewWithS3Data creates a bucket view handler that includes S3 instance data
+func createBucketViewWithS3Data(s3 S3, templates fs.FS, allowDelete bool, listRecursive bool, rootURL string, current *S3Instance, instances []*S3Instance) http.HandlerFunc {
+	type objectWithIcon struct {
+		Key          string
+		Size         int64
+		LastModified time.Time
+		Owner        string
+		Icon         string
+		IsFolder     bool
+		DisplayName  string
+	}
+
+	type pageData struct {
+		RootURL       string
+		BucketName    string
+		Objects       []objectWithIcon
+		AllowDelete   bool
+		Paths         []string
+		CurrentPath   string
+		CurrentS3     *S3Instance
+		S3Instances   []*S3Instance
+		HasError      bool
+		ErrorMessage  string
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		regex := regexp.MustCompile(`\/buckets\/([^\/]*)\/?(.*)`)
+		matches := regex.FindStringSubmatch(r.RequestURI)
+		bucketName := matches[1]
+		path := matches[2]
+
+		var objs []objectWithIcon
+		hasError := false
+		errorMessage := ""
+		
+		opts := minio.ListObjectsOptions{
+			Recursive: listRecursive,
+			Prefix:    path,
+		}
+		objectCh := s3.ListObjects(r.Context(), bucketName, opts)
+		for object := range objectCh {
+			if object.Err != nil {
+				// Instead of returning HTTP error, show user-friendly message
+				hasError = true
+				if strings.Contains(object.Err.Error(), "AccessDenied") || strings.Contains(object.Err.Error(), "InvalidAccessKeyId") || strings.Contains(object.Err.Error(), "SignatureDoesNotMatch") {
+					errorMessage = fmt.Sprintf("Unable to access bucket '%s' on S3 instance '%s'. Please check the credentials and try switching to another instance.", bucketName, current.Name)
+				} else if strings.Contains(object.Err.Error(), ErrBucketDoesNotExist) {
+					errorMessage = fmt.Sprintf("Bucket '%s' does not exist on S3 instance '%s'. Please try switching to another instance or go back to the buckets list.", bucketName, current.Name)
+				} else {
+					errorMessage = fmt.Sprintf("Unable to list objects in bucket '%s' on S3 instance '%s'. Please try switching to another instance.", bucketName, current.Name)
+				}
+				break
+			}
+
+			obj := objectWithIcon{
+				Key:          object.Key,
+				Size:         object.Size,
+				LastModified: object.LastModified,
+				Owner:        object.Owner.DisplayName,
+				Icon:         icon(object.Key),
+				IsFolder:     strings.HasSuffix(object.Key, "/"),
+				DisplayName:  strings.TrimSuffix(strings.TrimPrefix(object.Key, path), "/"),
+			}
+			objs = append(objs, obj)
+		}
+		
+		data := pageData{
+			RootURL:      rootURL,
+			BucketName:   bucketName,
+			Objects:      objs,
+			AllowDelete:  allowDelete,
+			Paths:        removeEmptyStrings(strings.Split(path, "/")),
+			CurrentPath:  path,
+			CurrentS3:    current,
+			S3Instances:  instances,
+			HasError:     hasError,
+			ErrorMessage: errorMessage,
+		}
+
+		t, err := template.ParseFS(templates, "layout.html.tmpl", "bucket.html.tmpl")
+		if err != nil {
+			handleHTTPError(w, fmt.Errorf("error parsing template files: %w", err))
+			return
+		}
+		err = t.ExecuteTemplate(w, "layout", data)
+		if err != nil {
+			handleHTTPError(w, fmt.Errorf("error executing template: %w", err))
+			return
+		}
+	}
+}

--- a/internal/app/s3manager/multi_s3_manager.go
+++ b/internal/app/s3manager/multi_s3_manager.go
@@ -1,0 +1,168 @@
+package s3manager
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+// S3Instance represents a configured S3 instance
+type S3Instance struct {
+	ID     string
+	Name   string
+	Client S3
+}
+
+// MultiS3Manager manages multiple S3 instances
+type MultiS3Manager struct {
+	instances      map[string]*S3Instance
+	currentID      string
+	instanceOrder  []string
+	mu             sync.RWMutex
+}
+
+// S3InstanceConfig holds configuration for a single S3 instance
+type S3InstanceConfig struct {
+	Name                string
+	Endpoint            string
+	UseIam              bool
+	IamEndpoint         string
+	AccessKeyID         string
+	SecretAccessKey     string
+	Region              string
+	UseSSL              bool
+	SkipSSLVerification bool
+	SignatureType       string
+}
+
+// NewMultiS3Manager creates a new MultiS3Manager with the given configurations
+func NewMultiS3Manager(configs []S3InstanceConfig) (*MultiS3Manager, error) {
+	manager := &MultiS3Manager{
+		instances:     make(map[string]*S3Instance),
+		instanceOrder: make([]string, 0, len(configs)),
+	}
+
+	for i, config := range configs {
+		instanceID := fmt.Sprintf("%d", i+1)
+		
+		// Set up S3 client options
+		opts := &minio.Options{
+			Secure: config.UseSSL,
+		}
+		
+		if config.UseIam {
+			opts.Creds = credentials.NewIAM(config.IamEndpoint)
+		} else {
+			var signatureType credentials.SignatureType
+			
+			switch config.SignatureType {
+			case "V2":
+				signatureType = credentials.SignatureV2
+			case "V4":
+				signatureType = credentials.SignatureV4
+			case "V4Streaming":
+				signatureType = credentials.SignatureV4Streaming
+			case "Anonymous":
+				signatureType = credentials.SignatureAnonymous
+			default:
+				return nil, fmt.Errorf("invalid SIGNATURE_TYPE: %s", config.SignatureType)
+			}
+			
+			opts.Creds = credentials.NewStatic(config.AccessKeyID, config.SecretAccessKey, "", signatureType)
+		}
+		
+		if config.Region != "" {
+			opts.Region = config.Region
+		}
+		
+		if config.UseSSL && config.SkipSSLVerification {
+			opts.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}} //nolint:gosec
+		}
+		
+		// Create S3 client
+		s3Client, err := minio.New(config.Endpoint, opts)
+		if err != nil {
+			return nil, fmt.Errorf("error creating s3 client for instance %s: %w", config.Name, err)
+		}
+		
+		instance := &S3Instance{
+			ID:     instanceID,
+			Name:   config.Name,
+			Client: s3Client,
+		}
+		
+		manager.instances[instanceID] = instance
+		manager.instanceOrder = append(manager.instanceOrder, instanceID)
+		
+		// Set the first instance as current
+		if i == 0 {
+			manager.currentID = instanceID
+		}
+	}
+	
+	if len(manager.instances) == 0 {
+		return nil, fmt.Errorf("no S3 instances configured")
+	}
+	
+	log.Printf("Initialized MultiS3Manager with %d instances", len(manager.instances))
+	return manager, nil
+}
+
+// GetCurrentClient returns the currently active S3 client
+func (m *MultiS3Manager) GetCurrentClient() S3 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	
+	instance, exists := m.instances[m.currentID]
+	if !exists && len(m.instances) > 0 {
+		// Fallback to first instance if current doesn't exist
+		m.currentID = m.instanceOrder[0]
+		instance = m.instances[m.currentID]
+	}
+	return instance.Client
+}
+
+// GetCurrentInstance returns the currently active S3 instance info
+func (m *MultiS3Manager) GetCurrentInstance() *S3Instance {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	
+	instance, exists := m.instances[m.currentID]
+	if !exists && len(m.instances) > 0 {
+		// Fallback to first instance if current doesn't exist
+		m.currentID = m.instanceOrder[0]
+		instance = m.instances[m.currentID]
+	}
+	return instance
+}
+
+// SetCurrentInstance switches to the specified S3 instance
+func (m *MultiS3Manager) SetCurrentInstance(instanceID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	
+	if _, exists := m.instances[instanceID]; !exists {
+		return fmt.Errorf("S3 instance with ID %s not found", instanceID)
+	}
+	
+	m.currentID = instanceID
+	log.Printf("Switched to S3 instance: %s (%s)", instanceID, m.instances[instanceID].Name)
+	return nil
+}
+
+// GetAllInstances returns all available S3 instances
+func (m *MultiS3Manager) GetAllInstances() []*S3Instance {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	
+	instances := make([]*S3Instance, 0, len(m.instanceOrder))
+	for _, id := range m.instanceOrder {
+		instances = append(instances, m.instances[id])
+	}
+	return instances
+}

--- a/web/template/bucket.html.tmpl
+++ b/web/template/bucket.html.tmpl
@@ -14,7 +14,7 @@
 <nav class="nav-extended">
     <div class="nav-wrapper container">
         <a href="{{$.RootURL}}/buckets/{{$.BucketName}}" class="brand-logo center"><i class="material-icons">folder_open</i>{{ .BucketName }}</a>
-        {{ if not .Objects }}
+        {{ if and (not .Objects) (not .HasError) }}
         <ul class="right">
             <li>
                 <a class="waves-effect waves-light btn" href="#" onclick="deleteBucket({{ .BucketName }})">
@@ -23,6 +23,11 @@
             </li>
         </ul>
         {{ end }}
+        <ul class="left">
+            {{ if .CurrentS3 }}
+            <li><span><i class="material-icons left">storage</i>{{ .CurrentS3.Name }}</span></li>
+            {{ end }}
+        </ul>
     </div>
 
     <div class="nav-wrapper container">
@@ -39,7 +44,33 @@
 </nav>
 
 <div class="section" style="margin: 10px; position: relative;">
-    {{ if .Objects }}
+    {{ if .HasError }}
+    <div class="row">
+        <div class="col s12">
+            <div class="card red lighten-4">
+                <div class="card-content">
+                    <div class="row">
+                        <div class="col s1">
+                            <i class="material-icons large red-text">error</i>
+                        </div>
+                        <div class="col s11">
+                            <span class="card-title red-text text-darken-2">Connection Error</span>
+                            <p>{{ .ErrorMessage }}</p>
+                            {{ if gt (len .S3Instances) 1 }}
+                            <p><strong>Tip:</strong> Use the instance switcher button (bottom-left) to try a different S3 instance.</p>
+                            {{ end }}
+                            <div style="margin-top: 20px;">
+                                <a href="{{$.RootURL}}/buckets" class="waves-effect waves-green btn">
+                                    <i class="material-icons left">arrow_back</i>Go back to buckets
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    {{ else if .Objects }}
     <table class="striped">
         <thead>
             <tr>
@@ -83,9 +114,7 @@
             {{ end }}
         </tbody>
     </table>
-    {{ end }}
-
-    {{ if not .Objects }}
+    {{ else }}
     <p style="text-align:center;margin-top:2em;color:gray;">No objects in <strong>{{ .BucketName }}/{{ .CurrentPath }}</strong> yet</p>
     {{ end }}
 
@@ -102,6 +131,7 @@
     </div>
 </div>
 
+{{ if not .HasError }}
 <div class="fixed-action-btn">
     <button type="button" class="btn-floating btn-large red tooltipped" id="upload-file-btn" data-position="top" data-tooltip="Upload files">
         <i class="large material-icons">add</i>
@@ -115,6 +145,7 @@
         <i class="large material-icons">create</i>
     </button>
 </div>
+{{ end }}
 
 <input type="file" id="upload-folder-input" webkitdirectory multiple style="display: none;">
 <input type="file" id="upload-file-input" name="file" multiple style="display: none;">

--- a/web/template/buckets.html.tmpl
+++ b/web/template/buckets.html.tmpl
@@ -2,6 +2,11 @@
 <nav>
     <div class="nav-wrapper container">
         <a href="{{$.RootURL}}" class="brand-logo">S3 Manager</a>
+        {{ if .CurrentS3 }}
+        <span class="right">
+            <i class="material-icons left">storage</i>{{ .CurrentS3.Name }}
+        </span>
+        {{ end }}
     </div>
 </nav>
 
@@ -9,7 +14,26 @@
     <div class="section">
         <div class="row">
 
-            {{ if .Buckets }}
+            {{ if .HasError }}
+            <div class="col s12">
+                <div class="card red lighten-4">
+                    <div class="card-content">
+                        <div class="row">
+                            <div class="col s2">
+                                <i class="material-icons large red-text">error</i>
+                            </div>
+                            <div class="col s10">
+                                <span class="card-title red-text text-darken-2">Connection Error</span>
+                                <p>{{ .ErrorMessage }}</p>
+                                {{ if gt (len .S3Instances) 1 }}
+                                <p><strong>Tip:</strong> Use the instance switcher button (bottom-left) to try a different S3 instance.</p>
+                                {{ end }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {{ else if .Buckets }}
             {{ range $bucket := .Buckets }}
             <div class="col l6 m12">
                 <a href="{{$.RootURL}}/buckets/{{ $bucket.Name }}" style="color:black;">
@@ -31,9 +55,7 @@
                 </a>
             </div>
             {{ end }}
-            {{ end }}
-
-            {{ if not .Buckets }}
+            {{ else }}
             <p style="text-align:center;margin-top:2em;color:gray;">No buckets yet</p>
             {{ end }}
 
@@ -41,11 +63,13 @@
     </div>
 </div>
 
+{{ if not .HasError }}
 <div class="fixed-action-btn">
     <button type="button" class="btn-floating btn-large red modal-trigger" data-target="modal-create-bucket">
         <i class="material-icons large">add</i>
     </button>
 </div>
+{{ end }}
 
 <div id="modal-create-bucket" class="modal">
     <form id="create-bucket-form">

--- a/web/template/layout.html.tmpl
+++ b/web/template/layout.html.tmpl
@@ -11,11 +11,79 @@
 
     <link rel="stylesheet" href="{{$.RootURL}}/static/css/material-fonts.css" />
     <link rel="stylesheet" href="{{$.RootURL}}/static/css/materialize.min.css" />
+    <style>
+        .s3-instance-switcher {
+            position: fixed;
+            bottom: 20px;
+            left: 20px;
+            z-index: 1000;
+        }
+        .s3-instance-button {
+            background-color: #2196F3;
+            color: white;
+            border: none;
+            border-radius: 50%;
+            width: 56px;
+            height: 56px;
+            cursor: pointer;
+            box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 16px;
+        }
+        .s3-instance-button:hover {
+            background-color: #1976D2;
+        }
+        .s3-instance-dropdown {
+            position: absolute;
+            bottom: 65px;
+            left: 0;
+            background: white;
+            border-radius: 4px;
+            box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+            min-width: 200px;
+            display: none;
+        }
+        .s3-instance-item {
+            padding: 12px 16px;
+            cursor: pointer;
+            border-bottom: 1px solid #eee;
+        }
+        .s3-instance-item:hover {
+            background-color: #f5f5f5;
+        }
+        .s3-instance-item.active {
+            background-color: #e3f2fd;
+            color: #1976d2;
+            font-weight: bold;
+        }
+        .s3-instance-item:last-child {
+            border-bottom: none;
+        }
+    </style>
 </head>
 
 <body>
 
     {{ template "content" . }}
+
+    <!-- S3 Instance Switcher -->
+    {{ if and .S3Instances (gt (len .S3Instances) 1) }}
+    <div class="s3-instance-switcher">
+        <button class="s3-instance-button" onclick="toggleS3Dropdown()">
+            <i class="material-icons">storage</i>
+        </button>
+        <div id="s3-instance-dropdown" class="s3-instance-dropdown">
+            {{ range .S3Instances }}
+            <div class="s3-instance-item {{ if eq .ID $.CurrentS3.ID }}active{{ end }}" 
+                 onclick="switchS3Instance('{{ .ID }}', '{{ .Name }}')">
+                {{ .Name }}
+            </div>
+            {{ end }}
+        </div>
+    </div>
+    {{ end }}
 
     <script
       src="{{$.RootURL}}/static/js/jquery-3.6.0.min.js"
@@ -25,6 +93,40 @@
         $(document).ready(function(){
             $('.dropdown-trigger').dropdown();
             $('.modal').modal();
+        });
+
+        function toggleS3Dropdown() {
+            const dropdown = document.getElementById('s3-instance-dropdown');
+            dropdown.style.display = dropdown.style.display === 'block' ? 'none' : 'block';
+        }
+
+        function switchS3Instance(instanceId, instanceName) {
+            $.ajax({
+                type: 'POST',
+                url: '{{$.RootURL}}/api/s3-instances/' + instanceId + '/switch',
+                success: function() {
+                    // Show toast notification
+                    M.toast({html: 'Switched to: ' + instanceName});
+                    // Always redirect to buckets list when switching instances
+                    setTimeout(function() {
+                        window.location.href = '{{$.RootURL}}/buckets';
+                    }, 1000);
+                },
+                error: function() {
+                    M.toast({html: 'Failed to switch S3 instance'});
+                }
+            });
+            // Hide dropdown
+            document.getElementById('s3-instance-dropdown').style.display = 'none';
+        }
+
+        // Close dropdown when clicking outside
+        document.addEventListener('click', function(event) {
+            const switcher = document.querySelector('.s3-instance-switcher');
+            const dropdown = document.getElementById('s3-instance-dropdown');
+            if (!switcher.contains(event.target)) {
+                dropdown.style.display = 'none';
+            }
         });
     </script>
 </body>


### PR DESCRIPTION
<img width="287" height="194" alt="image" src="https://github.com/user-attachments/assets/acff4c39-ed61-4f73-afba-be8d1e171dfa" />

**Add support for multiple S3 backends with environment-based configuration.**

This PR introduces the ability to configure and manage multiple S3 backends within a single instance of s3manager. Users can define multiple S3 instances via environment variables prefixed with numeric identifiers (e.g. 1_NAME, 1_ACCESS_KEY_ID, 2_NAME, etc.), enabling dynamic management of multiple S3-compatible storage providers or accounts.

Key changes include:
-  A new MultiS3Manager to handle multiple S3 clients and switching between them.
-  Parsing of numbered environment variables to load multiple S3 instance configurations.
- Updated HTTP handlers and UI templates to support instance switching and display buckets across configured S3 backends.
- Backward compatibility with existing single-instance configuration.
- Example environment setup added in docker-compose.yml showcasing configuration of two S3 instances.

Cheers ;)