### PR TITLE
feat: add public share link functionality and improve error handling

### DIFF
--- a/internal/app/s3manager/bucket_view.go
+++ b/internal/app/s3manager/bucket_view.go
@@ -26,12 +26,16 @@ func HandleBucketView(s3 S3, templates fs.FS, allowDelete bool, listRecursive bo
 	}
 
 	type pageData struct {
-		RootURL     string
-		BucketName  string
-		Objects     []objectWithIcon
-		AllowDelete bool
-		Paths       []string
-		CurrentPath string
+		RootURL      string
+		BucketName   string
+		Objects      []objectWithIcon
+		AllowDelete  bool
+		Paths        []string
+		CurrentPath  string
+		Endpoint     string
+		CurrentS3    *S3Instance
+		HasError     bool
+		ErrorMessage string
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -70,6 +74,7 @@ func HandleBucketView(s3 S3, templates fs.FS, allowDelete bool, listRecursive bo
 			AllowDelete: allowDelete,
 			Paths:       removeEmptyStrings(strings.Split(path, "/")),
 			CurrentPath: path,
+			Endpoint:    s3.EndpointURL().String(),
 		}
 
 		t, err := template.ParseFS(templates, "layout.html.tmpl", "bucket.html.tmpl")

--- a/internal/app/s3manager/bucket_view_test.go
+++ b/internal/app/s3manager/bucket_view_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -185,6 +186,10 @@ func TestHandleBucketView(t *testing.T) {
 
 			s3 := &mocks.S3Mock{
 				ListObjectsFunc: tc.listObjectsFunc,
+				EndpointURLFunc: func() *url.URL {
+					u, _ := url.Parse("http://localhost:9000")
+					return u
+				},
 			}
 
 			templates := os.DirFS(filepath.Join("..", "..", "..", "web", "template"))

--- a/internal/app/s3manager/buckets_view.go
+++ b/internal/app/s3manager/buckets_view.go
@@ -12,9 +12,12 @@ import (
 // HandleBucketsView renders all buckets on an HTML page.
 func HandleBucketsView(s3 S3, templates fs.FS, allowDelete bool, rootURL string) http.HandlerFunc {
 	type pageData struct {
-		RootURL     string
-		Buckets     []minio.BucketInfo
-		AllowDelete bool
+		RootURL      string
+		Buckets      []minio.BucketInfo
+		AllowDelete  bool
+		CurrentS3    *S3Instance
+		HasError     bool
+		ErrorMessage string
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/s3manager/public_access.go
+++ b/internal/app/s3manager/public_access.go
@@ -1,0 +1,56 @@
+package s3manager
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+)
+
+// HandleCheckPublicAccess checks if an object is publicly accessible.
+func HandleCheckPublicAccess(s3 S3) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		bucketName := mux.Vars(r)["bucketName"]
+		objectName := mux.Vars(r)["objectName"]
+
+		endpoint := s3.EndpointURL().String()
+		if !strings.HasSuffix(endpoint, "/") {
+			endpoint += "/"
+		}
+		
+		// Construct the public URL
+		// Note: This assumes path-style access (http://endpoint/bucket/object)
+		// which is typical for MinIO and generic S3. 
+		url := fmt.Sprintf("%s%s/%s", endpoint, bucketName, objectName)
+
+		// Perform a HEAD request to check accessibility without downloading content
+		resp, err := http.Head(url)
+		isAccessible := false
+		statusCode := 0
+
+		if err != nil {
+			// If we can't reach it, it's definitely not accessible or there's a network issue
+			// We treat this as not accessible for the user's purpose
+			isAccessible = false
+		} else {
+			defer resp.Body.Close()
+			statusCode = resp.StatusCode
+			// 200 OK means accessible. 
+			// We might also consider 304 Not Modified as accessible if that ever happens on a fresh HEAD.
+			isAccessible = resp.StatusCode == http.StatusOK
+		}
+
+		response := map[string]interface{}{
+			"accessible": isAccessible,
+			"statusCode": statusCode,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			handleHTTPError(w, fmt.Errorf("error encoding JSON: %w", err))
+			return
+		}
+	}
+}

--- a/internal/app/s3manager/public_access_test.go
+++ b/internal/app/s3manager/public_access_test.go
@@ -1,0 +1,96 @@
+package s3manager_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/cloudlena/s3manager/internal/app/s3manager"
+	"github.com/cloudlena/s3manager/internal/app/s3manager/mocks"
+	"github.com/gorilla/mux"
+	"github.com/matryer/is"
+)
+
+func TestHandleCheckPublicAccess(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		it                 string
+		s3ResponseStatus   int
+		expectAccessible   bool
+		expectStatusCode   int
+		networkError       bool
+	}{
+		{
+			it:               "reports accessible when S3 returns 200 OK",
+			s3ResponseStatus: http.StatusOK,
+			expectAccessible: true,
+			expectStatusCode: http.StatusOK,
+		},
+		{
+			it:               "reports not accessible when S3 returns 403 Forbidden",
+			s3ResponseStatus: http.StatusForbidden,
+			expectAccessible: false,
+			expectStatusCode: http.StatusForbidden,
+		},
+		{
+			it:               "reports not accessible when S3 returns 404 Not Found",
+			s3ResponseStatus: http.StatusNotFound,
+			expectAccessible: false,
+			expectStatusCode: http.StatusNotFound,
+		},
+		{
+			it:               "reports not accessible on network error",
+			networkError:     true,
+			expectAccessible: false,
+			expectStatusCode: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.it, func(t *testing.T) {
+			is := is.New(t)
+
+			// Start a mock S3 server to respond to the HEAD request
+			var s3ServerURL string
+			if !tc.networkError {
+				s3Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					is.Equal(http.MethodHead, r.Method)
+					w.WriteHeader(tc.s3ResponseStatus)
+				}))
+				defer s3Server.Close()
+				s3ServerURL = s3Server.URL
+			} else {
+				// Use an invalid port to simulate a network error
+				s3ServerURL = "http://localhost:0"
+			}
+
+			s3 := &mocks.S3Mock{
+				EndpointURLFunc: func() *url.URL {
+					u, _ := url.Parse(s3ServerURL)
+					return u
+				},
+			}
+
+			handler := s3manager.HandleCheckPublicAccess(s3)
+			r := mux.NewRouter()
+			r.Handle("/api/buckets/{bucketName}/objects/{objectName:.*}/public-access", handler)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/buckets/my-bucket/objects/my-file.txt/public-access", nil)
+			rr := httptest.NewRecorder()
+
+			r.ServeHTTP(rr, req)
+
+			is.Equal(http.StatusOK, rr.Code)
+
+			var response map[string]interface{}
+			err := json.Unmarshal(rr.Body.Bytes(), &response)
+			is.NoErr(err)
+
+			is.Equal(tc.expectAccessible, response["accessible"])
+			is.Equal(float64(tc.expectStatusCode), response["statusCode"])
+		})
+	}
+}

--- a/internal/app/s3manager/s3.go
+++ b/internal/app/s3manager/s3.go
@@ -21,6 +21,7 @@ type S3 interface {
 	PutObject(ctx context.Context, bucketName, objectName string, reader io.Reader, objectSize int64, opts minio.PutObjectOptions) (minio.UploadInfo, error)
 	RemoveBucket(ctx context.Context, bucketName string) error
 	RemoveObject(ctx context.Context, bucketName, objectName string, opts minio.RemoveObjectOptions) error
+	EndpointURL() *url.URL
 }
 
 // SSEType describes a type of server side encryption.

--- a/main.go
+++ b/main.go
@@ -206,6 +206,7 @@ func main() {
 	}
 	r.Handle("/api/buckets/{bucketName}/objects", s3manager.HandleCreateObjectWithManager(s3Manager, sseType)).Methods(http.MethodPost)
 	r.Handle("/api/buckets/{bucketName}/objects/{objectName:.*}/url", s3manager.HandleGenerateURLWithManager(s3Manager)).Methods(http.MethodGet)
+	r.Handle("/api/buckets/{bucketName}/objects/{objectName:.*}/public-access", s3manager.HandleCheckPublicAccessWithManager(s3Manager)).Methods(http.MethodGet)
 	r.Handle("/api/buckets/{bucketName}/objects/{objectName:.*}", s3manager.HandleGetObjectWithManager(s3Manager, configuration.ForceDownload)).Methods(http.MethodGet)
 	if configuration.AllowDelete {
 		r.Handle("/api/buckets/{bucketName}/objects/{objectName:.*}", s3manager.HandleDeleteObjectWithManager(s3Manager)).Methods(http.MethodDelete)

--- a/web/template/bucket.html.tmpl
+++ b/web/template/bucket.html.tmpl
@@ -103,9 +103,10 @@
                         <!-- Dropdown Structure -->
                         <ul id="actions-dropdown-{{ $index }}" class="dropdown-content">
                             <li><a target="_blank" href="{{$.RootURL}}/api/buckets/{{ $.BucketName }}/objects/{{ $object.Key }}">Download</a></li>
-                            <li><a onclick="handleOpenDownloadLinkModal({{ $object.Key }})">Download link</a></li>
+                            <li><a onclick="handleOpenDownloadLinkModal('{{ $object.Key }}')">Download link</a></li>
+                            <li><a onclick="handleOpenPublicLinkModal('{{ $object.Key }}')">Public link</a></li>
                             {{- if $.AllowDelete }}
-                            <li><a href="#" onclick="deleteObject({{ $.BucketName }}, {{ $object.Key }})">Delete</a></li>
+                            <li><a href="#" onclick="deleteObject('{{ $.BucketName }}', '{{ $object.Key }}')">Delete</a></li>
                             {{- end }}
                         </ul>
                     {{ end }}
@@ -217,6 +218,46 @@
             </div>
         </div>
     </form>
+</div>
+
+<div id="modal-create-public-link" class="modal">
+    <div class="modal-content">
+        <div class="row">
+            <h4>Public link for </h4>
+            <input name="objectName" id="public-link-object-name" type="text" readonly>
+        </div>
+
+        <div class="row">
+            <div class="col s12">
+                <label>
+                    <input type="checkbox" id="public-link-confirm" onchange="togglePublicLinkVisibility()" />
+                    <span>I understand that handing out this link is irrevocable, and anyone with the link can access the file for as long as it exists.</span>
+                </label>
+            </div>
+        </div>
+
+        <div id="public-link-container" style="display: none;">
+            <div class="row">
+                <div class="col s12 center-align">
+                    <div id="public-access-status" style="display: inline-block; margin-bottom: 15px; padding: 10px; border-radius: 4px;">
+                        <!-- Status will be injected here -->
+                    </div>
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="col s11">
+                    <div class="input-field">
+                        <i class="material-icons prefix" onclick="handleCopyPublicLink()" style="cursor:pointer;">content_copy</i>
+                        <input name="public-link" id="public-link" type="text" readonly>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="modal-footer">
+        <button type="button" class="modal-close waves-effect waves-green btn-flat">Close</button>
+    </div>
 </div>
 
 <script>
@@ -343,6 +384,91 @@ function handleGenerateDownloadLink(event) {
 
 function handleCopyLink() {
     const url = document.getElementById("generated-link").value;
+
+    if(!!url) {
+        navigator.clipboard.writeText(url).then(function() {
+            M.toast({html: 'Copied to clipboard!'});
+        }, function(err) {
+            console.error('Could not copy:', err);
+        });
+    }
+}
+
+function handleOpenPublicLinkModal(objectName) {
+    const endpoint = "{{ .Endpoint }}";
+    const bucketName = "{{ .BucketName }}";
+    const separator = endpoint.endsWith('/') ? '' : '/';
+    const url = endpoint + separator + bucketName + "/" + objectName;
+
+    document.getElementById('public-link-object-name').value = objectName;
+    document.getElementById('public-link').value = url;
+    
+    // Reset state
+    document.getElementById('public-link-confirm').checked = false;
+    document.getElementById('public-link-container').style.display = 'none';
+
+    // Reset and start public access check
+    const statusDiv = document.getElementById('public-access-status');
+    statusDiv.className = ""; // Reset classes
+    statusDiv.innerHTML = `
+        <div class="blue-text" style="display: flex; align-items: center; justify-content: center;">
+            <div class="preloader-wrapper small active" style="width: 20px; height: 20px; margin-right: 10px;">
+                <div class="spinner-layer spinner-blue-only">
+                    <div class="circle-clipper left"><div class="circle"></div></div>
+                    <div class="gap-patch"><div class="circle"></div></div>
+                    <div class="circle-clipper right"><div class="circle"></div></div>
+                </div>
+            </div>
+            Verifying public accessibility...
+        </div>`;
+
+    $.ajax({
+        type: 'GET',
+        url: '{{$.RootURL}}/api/buckets/' + bucketName + '/objects/' + objectName + '/public-access',
+        success: function (result) {
+            if (result.accessible) {
+                statusDiv.className = "green lighten-5";
+                statusDiv.innerHTML = `
+                    <div class="green-text text-darken-2" style="display: flex; align-items: center; justify-content: center;">
+                        <i class="material-icons" style="margin-right: 10px;">check_circle</i>
+                        The file seems to be publicly available.
+                    </div>`;
+            } else {
+                statusDiv.className = "red lighten-5";
+                statusDiv.innerHTML = `
+                    <div class="red-text text-darken-2" style="display: flex; align-items: center; justify-content: center;">
+                        <i class="material-icons" style="margin-right: 10px;">error</i>
+                        The file does not seem to be publicly available. Make sure the bucket policy allows public read access.
+                    </div>`;
+            }
+        },
+        error: function() {
+            statusDiv.className = "orange lighten-5";
+            statusDiv.innerHTML = `
+                <div class="orange-text text-darken-4" style="display: flex; align-items: center; justify-content: center;">
+                    <i class="material-icons" style="margin-right: 10px;">warning</i>
+                    Could not verify accessibility.
+                </div>`;
+        }
+    });
+
+    const modalElement = document.getElementById('modal-create-public-link');
+    const modalInstance = M.Modal.init(modalElement);
+    modalInstance.open();
+}
+
+function togglePublicLinkVisibility() {
+    const isChecked = document.getElementById('public-link-confirm').checked;
+    const container = document.getElementById('public-link-container');
+    if (isChecked) {
+        container.style.display = 'block';
+    } else {
+        container.style.display = 'none';
+    }
+}
+
+function handleCopyPublicLink() {
+    const url = document.getElementById("public-link").value;
 
     if(!!url) {
         navigator.clipboard.writeText(url).then(function() {


### PR DESCRIPTION
For my use case, I needed a way to generate permalinks to files. If anybody finds this useful, feel free to merge. 

I have added a file menu option with some warnings so users understand what they're doing, as well as a simple test of permalink access for the user to know whether the bucket is configured for this or not. Some tests as well.


I also fixed some missing JS quotes in the template, and it got swept in the same commit.
