### PR TITLE
Display object Last Modified times in the local timezone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ WORKDIR /usr/src/app
 RUN addgroup -S s3manager && adduser -S s3manager -G s3manager
 RUN apk add --no-cache \
   ca-certificates \
-  dumb-init
+  dumb-init \
+  tzdata
 COPY --from=builder --chown=s3manager:s3manager /usr/src/app/bin/s3manager ./
 USER s3manager
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The application can be configured with the following environment variables:
 - `ALLOW_DELETE`: Enable buttons to delete objects (defaults to `true`)
 - `FORCE_DOWNLOAD`: Add response headers for object downloading instead of opening in a new tab (defaults to `true`)
 - `LIST_RECURSIVE`: List all objects in buckets recursively (defaults to `false`)
+- `TZ`: IANA timezone used when displaying object Last Modified times (defaults to UTC; for example `Europe/Berlin`)
 - `BUCKET_NAME`: Restrict the buckets view to a single named bucket (defaults to unset, showing all buckets)
 - `USE_IAM`: Use IAM role instead of key pair (defaults to `false`)
 - `IAM_ENDPOINT`: Endpoint for IAM role retrieving (Can be blank for AWS)

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/cloudlena/adapters/logging"
 	"github.com/cloudlena/s3manager/internal/app/s3manager"

--- a/web/template/bucket.html.tmpl
+++ b/web/template/bucket.html.tmpl
@@ -216,7 +216,7 @@
                 </td>
                 <td>{{ $object.SizeDisplay }}</td>
                 <td>{{ $object.Owner }}</td>
-                <td>{{ $object.LastModified }}</td>
+                <td>{{ $object.LastModified.Local.Format "2006-01-02 15:04:05 MST" }}</td>
                 <td>
                     {{ if not $object.IsFolder }}
                         <button class="dropdown-trigger waves-effect waves-teal btn" data-target="actions-dropdown-{{ $index }}">


### PR DESCRIPTION
## Summary

Object Last Modified timestamps in the bucket view were always shown in UTC (`time.Time` default formatting), which is awkward for operators who work in a regional timezone.

This change formats Last Modified with `time.Local` and documents the standard `TZ` environment variable so deployments can display wall-clock times (for example `Europe/Berlin`).

## Changes

- Format Last Modified as `2006-01-02 15:04:05 MST` via `time.Local` in the bucket template
- Import `time/tzdata` so timezone data is embedded in the binary
- Install `tzdata` in the Alpine runtime image
- Document `TZ` in the README configuration list

## Compatibility

- Without `TZ`, behavior remains UTC (same as before for typical containers)
- With `TZ` set to an IANA zone (for example `Europe/Berlin`), the UI shows local time
- No API or configuration breaking changes

## Test plan

- [ ] Build the image and run with `TZ=Europe/Berlin`
- [ ] Open a bucket listing and confirm Last Modified shows a local offset/abbreviation (for example `CEST`) rather than `+0000 UTC`
- [ ] Run without `TZ` and confirm timestamps remain in UTC
